### PR TITLE
Allow mixed geometry types

### DIFF
--- a/db.sql
+++ b/db.sql
@@ -108,7 +108,10 @@ CREATE TABLE openaddresses (
     hash           TEXT,
     canonical      TEXT,
 
-    geometry       GEOMETRY (Point, 4326),
+    -- Geometry values from OpenAddresses may be any geometry type, not just
+    -- ``POINT``.  Use a general ``GEOMETRY`` column while keeping the SRID of
+    -- 4326 which matches the source data.
+    geometry       GEOMETRY (Geometry, 4326),
 
     CONSTRAINT unique_openaddresses_record
         UNIQUE (job_id, hash, geometry)

--- a/oa_etl/core/staging.py
+++ b/oa_etl/core/staging.py
@@ -42,7 +42,10 @@ async def create_temp_staging_table(
         column_defs.append(sql.SQL("{} TEXT").format(sql.Identifier(col)))
     for col in METADATA_HEADER:
         column_defs.append(sql.SQL("{} TEXT").format(sql.Identifier(col)))
-    column_defs.append(sql.SQL("geometry GEOMETRY(Point, 4326)"))
+    # Geometry can be any valid type, so avoid constraining to only ``POINT``
+    # in the staging table. Keep the SRID of 4326 which matches the source
+    # data used throughout the pipeline.
+    column_defs.append(sql.SQL("geometry GEOMETRY(Geometry, 4326)"))
     column_defs.append(sql.SQL("address_hash BYTEA"))
 
     create_table_q = sql.SQL(


### PR DESCRIPTION
## Summary
- accept any geometry type in openaddresses table
- relax staging temp table to allow any geometry type

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6886517b8f8483329fbf28e49b50b5c5